### PR TITLE
dev: added Hardware and Software flow control options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A universal PowerShell script for serial port communication that combines listen
 ## Features
 
 - Configurable serial port settings (port, baud rate, parity, data bits, stop bits)
+- Flow control support: RTS/CTS (hardware) and XON/XOFF (software), independently or combined
+- Configurable write timeout to prevent hangs when flow control stalls
 - Predefined configurations for common scenarios
 - Send commands from a file with configurable delay
 - Recursive command execution mode
@@ -29,6 +31,9 @@ A universal PowerShell script for serial port communication that combines listen
 | -Parity            | Parity (None, Even, Odd, Mark, Space)           | None           |
 | -DataBits          | Data bits (5, 6, 7, 8)                          | 8              |
 | -StopBits          | Stop bits (One, Two, OnePointFive)              | One            |
+| -RtsCts            | Enable RTS/CTS hardware flow control            | False          |
+| -XonXoff           | Enable XON/XOFF software flow control           | False          |
+| -WriteTimeout      | Write timeout in ms (use -1 for infinite)       | 5000           |
 | -WindowTitle       | Terminal window title                           | Serial Port Master |
 | -CommandFile       | File containing commands to send                |                |
 | -CommandDelay      | Delay between commands in milliseconds          | 1000           |
@@ -45,6 +50,27 @@ A universal PowerShell script for serial port communication that combines listen
 - **EnergyMeter**: 9600 baud, 7 data bits, Even parity, 1 stop bit
 - **RFEgypt**: 38400 baud, 7 data bits, Even parity, 1 stop bit
 - **Default**: 9600 baud, 8 data bits, No parity, 1 stop bit
+
+Presets do not set flow control. Combine a preset with `-RtsCts` and/or `-XonXoff` if the target device requires it.
+
+### Flow Control
+
+`-RtsCts` and `-XonXoff` are independent switches and map to `System.IO.Ports.Handshake` as follows:
+
+| `-RtsCts` | `-XonXoff` | Handshake mode         |
+|-----------|------------|------------------------|
+| off       | off        | None (default)         |
+| on        | off        | RequestToSend          |
+| off       | on        | XOnXOff                |
+| on        | on        | RequestToSendXOnXOff   |
+
+The resolved handshake mode is printed on startup and written to the log header.
+
+#### Things to be aware of
+
+- **CTS must be asserted for writes to proceed with `-RtsCts`.** If the peer never raises CTS, every `Write()` would block forever. `-WriteTimeout` (default 5000 ms) bounds this: a timed-out write is logged as an `ERROR` entry and the session continues instead of hanging. Set `-WriteTimeout -1` to restore the previous infinite-wait behaviour, or increase it for slow peers.
+- **XON/XOFF consumes 0x11 (DC1) and 0x13 (DC3).** When `-XonXoff` is on, those two bytes are intercepted by the driver as flow-control signals and never reach the receive side, so `[DC1]` / `[DC3]` will not appear in the console output or log for that session. This is driver behaviour, not a bug.
+- **Flow control cannot be changed after the port is open** — stop the script and relaunch with different switches to change modes.
 
 ## Examples
 
@@ -70,6 +96,19 @@ A universal PowerShell script for serial port communication that combines listen
 
 ```powershell
 .\SerialPortMaster.ps1 -PortName COM5 -Preset Sniffer -Interactive
+```
+
+### Enabling Flow Control
+
+```powershell
+# Hardware flow control (RTS/CTS) with a 10-second write timeout
+.\SerialPortMaster.ps1 -PortName COM3 -BaudRate 115200 -RtsCts -WriteTimeout 10000
+
+# Software flow control (XON/XOFF)
+.\SerialPortMaster.ps1 -PortName COM3 -XonXoff
+
+# Both hardware and software flow control together
+.\SerialPortMaster.ps1 -PortName COM3 -RtsCts -XonXoff
 ```
 
 ### Interactive Mode with Logging

--- a/SerialPortMaster.ps1
+++ b/SerialPortMaster.ps1
@@ -20,7 +20,16 @@ param (
     
     [Parameter(Mandatory=$false)]
     [string]$StopBits = "One",
-    
+
+    [Parameter(Mandatory=$false)]
+    [switch]$RtsCts,
+
+    [Parameter(Mandatory=$false)]
+    [switch]$XonXoff,
+
+    [Parameter(Mandatory=$false)]
+    [int]$WriteTimeout = 5000,
+
     [Parameter(Mandatory=$false)]
     [string]$WindowTitle = "Serial Port Master",
     
@@ -60,6 +69,9 @@ if ($h) {
     Write-Host "  -Parity       : Parity (None, Even, Odd, Mark, Space) (default: None)"
     Write-Host "  -DataBits     : Data bits (5, 6, 7, 8) (default: 8)"
     Write-Host "  -StopBits     : Stop bits (One, Two, OnePointFive) (default: One)"
+    Write-Host "  -RtsCts       : Enable RTS/CTS hardware flow control"
+    Write-Host "  -XonXoff      : Enable XON/XOFF software flow control (can combine with -RtsCts)"
+    Write-Host "  -WriteTimeout : Write timeout in milliseconds; prevents hangs when CTS is never asserted (default: 5000, use -1 for infinite)"
     Write-Host "  -WindowTitle  : Terminal window title (default: Serial Port Master)"
     Write-Host "  -CommandFile  : File containing commands to send"
     Write-Host "  -CommandDelay : Delay between commands in milliseconds (default: 1000)"
@@ -120,6 +132,17 @@ switch ($Preset) {
     }
 }
 
+# Determine flow control (handshake) mode from -RtsCts / -XonXoff switches
+if ($RtsCts -and $XonXoff) {
+    $handshakeValue = [System.IO.Ports.Handshake]::RequestToSendXOnXOff
+} elseif ($RtsCts) {
+    $handshakeValue = [System.IO.Ports.Handshake]::RequestToSend
+} elseif ($XonXoff) {
+    $handshakeValue = [System.IO.Ports.Handshake]::XOnXOff
+} else {
+    $handshakeValue = [System.IO.Ports.Handshake]::None
+}
+
 # Set the window title
 $host.UI.RawUI.WindowTitle = $WindowTitle
 
@@ -140,7 +163,7 @@ if ($LogFile) {
     
     # Initial log entries
     $initialEntry = "===== Serial Port Master Log - Started at $timestamp =====`r`n"
-    $initialEntry += "Port: $PortName, BaudRate: $BaudRate, DataBits: $DataBits, Parity: $Parity, StopBits: $StopBits`r`n"
+    $initialEntry += "Port: $PortName, BaudRate: $BaudRate, DataBits: $DataBits, Parity: $Parity, StopBits: $StopBits, Handshake: $handshakeValue`r`n"
     
     # Write directly to file
     [System.IO.File]::WriteAllText($LogFile, $initialEntry)
@@ -358,10 +381,15 @@ function Execute-CommandFile {
         }
         
         $parsedCmd = Parse-SpecialCharacters -InputString $cmd
-        $SerialPort.Write($parsedCmd)
-        Write-Host "Sent: $cmd" -ForegroundColor Yellow
-        Write-Log -Direction "SENT" -Message $cmd
-        
+        try {
+            $SerialPort.Write($parsedCmd)
+            Write-Host "Sent: $cmd" -ForegroundColor Yellow
+            Write-Log -Direction "SENT" -Message $cmd
+        } catch [TimeoutException] {
+            Write-Host "Write timeout sending: $cmd" -ForegroundColor Red
+            Write-Log -Direction "ERROR" -Message "Write timeout sending: $cmd"
+        }
+
         Start-Sleep -Milliseconds $Delay
         
         # Read any response
@@ -394,12 +422,14 @@ try {
     $stopBitsValue = [System.IO.Ports.StopBits]::$StopBits
     
     $port = New-Object System.IO.Ports.SerialPort $PortName, $BaudRate, $parityValue, $DataBits, $stopBitsValue
+    $port.Handshake = $handshakeValue
     $port.ReadTimeout = 1000  # Set a timeout for read operations in milliseconds
-    
+    $port.WriteTimeout = $WriteTimeout  # Prevents Write() from blocking forever if flow control stalls
+
     # Open the serial port
     $port.Open()
-    Write-Host "Serial port $($port.PortName) opened with settings: $BaudRate,$DataBits,$Parity,$StopBits" -ForegroundColor Green
-    Write-Log -Direction "INFO" -Message "Serial port $($port.PortName) opened with settings: $BaudRate,$DataBits,$Parity,$StopBits"
+    Write-Host "Serial port $($port.PortName) opened with settings: $BaudRate,$DataBits,$Parity,$StopBits Handshake=$handshakeValue" -ForegroundColor Green
+    Write-Log -Direction "INFO" -Message "Serial port $($port.PortName) opened with settings: $BaudRate,$DataBits,$Parity,$StopBits Handshake=$handshakeValue"
     Flush-LogBuffer
 
     # Process command file if specified
@@ -483,10 +513,15 @@ try {
                     if ($inputBuffer.Length -gt 0) {
                         Write-Host ""  # New line after input
                         $parsedInput = Parse-SpecialCharacters -InputString $inputBuffer
-                        $port.Write($parsedInput)
-                        Write-Host "Sent: $inputBuffer" -ForegroundColor Yellow
-                        Write-Log -Direction "SENT" -Message $inputBuffer
-                        
+                        try {
+                            $port.Write($parsedInput)
+                            Write-Host "Sent: $inputBuffer" -ForegroundColor Yellow
+                            Write-Log -Direction "SENT" -Message $inputBuffer
+                        } catch [TimeoutException] {
+                            Write-Host "Write timeout sending: $inputBuffer" -ForegroundColor Red
+                            Write-Log -Direction "ERROR" -Message "Write timeout sending: $inputBuffer"
+                        }
+
                         $inputBuffer = ""
                         $parsedInput = $null
                         $promptShown = $false


### PR DESCRIPTION
Hardware and Software flow control added. User needs to add writetimeout parameter for hardware flow control if not default parameter will be assigned from script to prevent hang when no write command appears.

Also XON/XOFF consuming DC1/DC3 is an issue where it is API level stuff.

Updated README.md